### PR TITLE
Added battery updating check

### DIFF
--- a/src/features/Bluetooth/BatteryObserver/BatteryObserverSlice.ts
+++ b/src/features/Bluetooth/BatteryObserver/BatteryObserverSlice.ts
@@ -18,6 +18,7 @@ import { SensorAction, SensorManager } from '~features/Entities';
 import { getDependency } from '~features/utils/saga';
 import { BleService } from 'msupply-ble-service';
 import { isSensorDownloading } from '../Download/DownloadSlice';
+import { RootState } from '~common/store';
 
 const INFO_RETRIES = 2;
 
@@ -34,6 +35,16 @@ export const BatteryObserverInitialState: BatteryObserverState = {
 interface BatteryUpdatePayload {
   sensorId: string;
 }
+
+export const isSensorUpdating =
+  (sensorId: string) =>
+  (state: RootState): boolean => {
+    try {
+      return state.bluetooth.batteryObserver.updatingById[sensorId] || false;
+    } catch {
+      return false;
+    }
+  };
 
 const reducers = {
   start: (draftState: BatteryObserverState) => {

--- a/src/features/Bluetooth/Download/DownloadSlice.ts
+++ b/src/features/Bluetooth/Download/DownloadSlice.ts
@@ -25,6 +25,7 @@ import {
 } from '~features';
 import { FileLoggerService } from '~common/services';
 import { RootState } from '~common/store';
+import { isSensorUpdating } from '../BatteryObserver/BatteryObserverSlice';
 
 const DOWNLOAD_RETRIES = 3;
 interface DownloadSliceState {
@@ -122,11 +123,14 @@ function* tryDownloadForSensor({
     const sensor = yield call(sensorManager.getSensorById, sensorId);
     const [canDownload] = yield call(sensorManager.getCanDownload, sensorId);
     const isDownloading = yield select(isSensorDownloading(sensorId));
+    const isUpdating = yield select(isSensorUpdating(sensorId));
+
+    const doDownload = canDownload && !isDownloading && !isUpdating;
 
     logger.debug(
-      `${sensorId} tryDownloadForSensor canDownload: ${canDownload} isDownloading: ${isDownloading}`
+      `${sensorId} tryDownloadForSensor canDownload: ${canDownload} isDownloading: ${isDownloading} isUpdating: ${isUpdating} doDownload: ${doDownload}`
     );
-    if (canDownload && !isDownloading) {
+    if (doDownload) {
       yield put(DownloadAction.downloadStart(sensorId));
 
       const { macAddress, logInterval, logDelay, programmedDate } = sensor;


### PR DESCRIPTION
Added a selector `isSensorUpdating`. This returns true if the specified sensor is currently having its battery data read.

The selector is used by the download slice to prevent a download happening at the same time.